### PR TITLE
Add TypeScript declarations to the published package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2661,7 +2661,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.2.tgz",
       "integrity": "sha512-+uWmsejEHfmSjyyM/LkrP0orfE2m5Mx9Xel4tXNeqi1ldK5XMQcDsFkBmLDtuyKUbxj2jGDo0H240fbCRJZo7Q==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -2676,7 +2675,6 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.5.3.tgz",
       "integrity": "sha512-89Ftby4+/qliA+Yb8FYMPYBryKdqnJ63FmZwZ0EFNI8HZ7adT9r2XxdMkqC9SdIOMfk39km9iFXr+obBm1dFGQ==",
-      "dev": true,
       "requires": {
         "@types/bson": "*",
         "@types/node": "*"
@@ -2686,7 +2684,6 @@
       "version": "5.7.7",
       "resolved": "https://registry.npmjs.org/@types/mongoose/-/mongoose-5.7.7.tgz",
       "integrity": "sha512-wfolAHiYVYTy9skgd8eKHF4KQ/fUJHPDO11ZWpeOE7JyNx/Snp/c91Jf5crrKutUFaiB702nIXQCyrA4MgGxRA==",
-      "dev": true,
       "requires": {
         "@types/mongodb": "*",
         "@types/node": "*"
@@ -2695,8 +2692,7 @@
     "@types/node": {
       "version": "12.12.31",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.31.tgz",
-      "integrity": "sha512-T+wnJno8uh27G9c+1T+a1/WYCHzLeDqtsGJkoEdSp2X8RTh3oOCZQcUnjAx90CS8cmmADX51O0FI/tu9s0yssg==",
-      "dev": true
+      "integrity": "sha512-T+wnJno8uh27G9c+1T+a1/WYCHzLeDqtsGJkoEdSp2X8RTh3oOCZQcUnjAx90CS8cmmADX51O0FI/tu9s0yssg=="
     },
     "@types/stack-utils": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "mongo"
   ],
   "files": [
-    "/dist"
+    "/dist",
+    "index.d.ts"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "node": ">=8"
   },
   "dependencies": {
+    "@types/mongodb": "^3.3.2",
+    "@types/mongoose": "^5.7.4",
     "apollo-datasource": "^0.3.1",
     "apollo-server-caching": "^0.3.1",
     "apollo-server-errors": "^2.2.1",
@@ -25,8 +27,6 @@
     "@babel/cli": "^7.4.3",
     "@babel/core": "^7.4.3",
     "@babel/preset-env": "^7.4.3",
-    "@types/mongodb": "^3.5.3",
-    "@types/mongoose": "^5.7.7",
     "babel-jest": "^24.7.1",
     "graphql": "^14.2.1",
     "jest": "^24.7.1",


### PR DESCRIPTION
Closes #19 

## What changed?

- Adds `index.d.ts` to `files` as mentioned [here](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package)
- Moves `@types/mongodb` and `@types/mongoose` to dependencies as mentioned [here](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#dependencies)

## How did I test it?

- Created a local package using `npm pack` and installed that in a project.
  - Ran `tsc` in that project, and there weren't any type errors.

cc @jblevins1991