### PR TITLE
deleteFromCacheById improvements

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,6 +40,6 @@ declare module 'apollo-datasource-mongodb' {
       options?: Options
     ): Promise<(TData | null | undefined)[]>
 
-    deleteFromCacheById(id: ObjectId): void
+    deleteFromCacheById(id: ObjectId): Promise<void>
   }
 }

--- a/src/cache.js
+++ b/src/cache.js
@@ -41,7 +41,10 @@ export const createCachingMethods = ({ collection, cache }) => {
     findManyByIds: (ids, { ttl } = {}) => {
       return Promise.all(ids.map(id => methods.findOneById(id, { ttl })))
     },
-    deleteFromCacheById: id => cache.delete(cachePrefix + id)
+    deleteFromCacheById: async id => {
+      loader.clear(id)
+      await cache.delete(cachePrefix + id)
+    }
   }
 
   return methods


### PR DESCRIPTION
- Fixed return type of `deleteFromCacheById`
    It returns a promise, which wasn't reflected in `index.d.ts`
- `deleteFromCacheById` should also clear the data loader cache. https://github.com/graphql/dataloader#clearing-cache