### PR TITLE
Include Model on createCachingMethods loader

### DIFF
--- a/src/__tests__/datasource.test.js
+++ b/src/__tests__/datasource.test.js
@@ -75,17 +75,19 @@ describe('Mongoose', () => {
     expect(getCollection(UserModel).collectionName).toBe('users')
   })
 
-  test('data source', async () => {
+  test('Data Source with Model', async () => {
     const users = new Users(UserModel)
     users.initialize()
     const user = await users.findOneById(alice._id)
     expect(user.name).toBe('Alice')
+    expect(user.id).toBe(alice._id.toString())
   })
 
-  test('collection', async () => {
+  test('Data Source with Collection', async () => {
     const users = new Users(userCollection)
     users.initialize()
     const user = await users.findOneById(alice._id)
     expect(user.name).toBe('Alice')
+    expect(user.id).toBeUndefined()
   })
 })

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -28,7 +28,7 @@ class MongoDataSource extends DataSource {
     this.context = context
 
     const methods = createCachingMethods({
-      collection: this.collection,
+      collection: this.model || this.collection,
       cache: cache || new InMemoryLRUCache()
     })
 


### PR DESCRIPTION
Similar to #28, but uses `Model.find().exec()` as promise, and checks if the `collection` parameter is Model.