### PR TITLE
Add findByFields method

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ Apollo [data source](https://www.apollographql.com/docs/apollo-server/features/d
 npm i apollo-datasource-mongodb
 ```
 
-This package uses [DataLoader](https://github.com/graphql/dataloader) for batching and per-request memoization caching. It also optionally (if you provide a `ttl`) does shared application-level caching (using either the default Apollo `InMemoryLRUCache` or the [cache you provide to ApolloServer()](https://www.apollographql.com/docs/apollo-server/features/data-sources#using-memcachedredis-as-a-cache-storage-backend)). It does this only for these two methods:
+This package uses [DataLoader](https://github.com/graphql/dataloader) for batching and per-request memoization caching. It also optionally (if you provide a `ttl`) does shared application-level caching (using either the default Apollo `InMemoryLRUCache` or the [cache you provide to ApolloServer()](https://www.apollographql.com/docs/apollo-server/features/data-sources#using-memcachedredis-as-a-cache-storage-backend)). It does this for the following methods:
 
 - [`findOneById(id, options)`](#findonebyid)
 - [`findManyByIds(ids, options)`](#findmanybyids)
+- [`findByFields(fields, options)`](#findbyfields)
 
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
@@ -24,6 +25,8 @@ This package uses [DataLoader](https://github.com/graphql/dataloader) for batchi
 - [API](#api)
   - [findOneById](#findonebyid)
   - [findManyByIds](#findmanybyids)
+  - [findByFields](#findbyfields)
+    - [Examples:](#examples)
   - [deleteFromCacheById](#deletefromcachebyid)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -183,6 +186,7 @@ interface UserDocument {
   username: string
   password: string
   email: string
+  interests: [string]
 }
 
 // This is optional
@@ -235,6 +239,39 @@ Resolves to the found document. Uses DataLoader to load `id`. DataLoader uses `c
 `this.findManyByIds(ids, { ttl })`
 
 Calls [`findOneById()`](#findonebyid) for each id. Resolves to an array of documents.
+
+### findByFields
+
+`this.findByFields(fields, { ttl })`
+
+Resolves to an array of documents matching the passed fields.
+
+fields has type `{ [fieldName: string]: string | number | boolean | [string | number | boolean] }`.
+
+#### Examples:
+
+```js
+
+  // get user by username
+  // `collection.find({ username: $in: ['testUser'] })`
+  this.getByFields({
+    username: 'testUser'
+  })
+
+  // get all users with either the "gaming" OR "games" interest
+  // `collection.find({ interests: $in: ['gaming', 'games'] })`
+  this.getByFields({
+    interests: ['gaming', 'games']
+  })
+
+  // get user by username AND with either the "gaming" OR "games" interest
+  // `collection.find({ username: $in: ['testUser'], interests: $in: ['gaming', 'games'] })`
+  this.getByFields({
+    username: 'testUser',
+    interests: ['gaming', 'games']
+  })
+
+```
 
 ### deleteFromCacheById
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,10 @@ declare module 'apollo-datasource-mongodb' {
   export type ModelOrCollection<T> = T extends Document
     ? Model<T>
     : Collection<T>
+  
+  export interface Fields {
+    [fieldName: string]: string | number | boolean | [string | number | boolean]
+  }
 
   export interface Options {
     ttl: number
@@ -37,6 +41,11 @@ declare module 'apollo-datasource-mongodb' {
 
     findManyByIds(
       ids: (ObjectId | string)[],
+      options?: Options
+    ): Promise<(TData | null | undefined)[]>
+
+    findByFields(
+      fields: Fields,
       options?: Options
     ): Promise<(TData | null | undefined)[]>
 

--- a/src/__tests__/cache.test.js
+++ b/src/__tests__/cache.test.js
@@ -89,14 +89,6 @@ describe('createCachingMethods', () => {
     expect(collection.find.mock.calls.length).toBe(1)
   })
 
-  // TODO why doesn't this pass?
-  // it.only(`doesn't cache without ttl`, async () => {
-  //   await api.findOneById(docs.id1._id)
-  //   await api.findOneById(docs.id1._id)
-
-  //   expect(collection.find.mock.calls.length).toBe(2)
-  // })
-
   it(`doesn't cache without ttl`, async () => {
     await api.findOneById(docs.one._id)
 

--- a/src/__tests__/cache.test.js
+++ b/src/__tests__/cache.test.js
@@ -9,15 +9,19 @@ const hexId = 'aaaa0000bbbb0000cccc0000'
 
 const docs = {
   one: {
-    _id: ObjectId(hexId)
+    _id: ObjectId(hexId),
+    foo: 'bar',
+    tags: ['foo', 'bar']
   },
   two: {
-    _id: ObjectId()
+    _id: ObjectId(),
+    foo: 'bar'
   }
 }
 
 const stringDoc = {
-  _id: 's2QBCnv6fXv5YbjAP'
+  _id: 's2QBCnv6fXv5YbjAP',
+  tags: ['bar', 'baz']
 }
 
 const collectionName = 'test'
@@ -31,30 +35,55 @@ describe('createCachingMethods', () => {
   beforeEach(() => {
     collection = {
       collectionName,
-      find: jest.fn(({ _id: { $in: ids } }) => ({
-        toArray: () =>
-          new Promise(resolve => {
-            setTimeout(
-              () =>
-                resolve(
-                  ids.map(id => {
-                    if (id === stringDoc._id) {
-                      return stringDoc
-                    }
-
-                    if (id.equals(docs.one._id)) {
-                      return docs.one
-                    }
-
-                    if (id.equals(docs.two._id)) {
-                      return docs.two
-                    }
-                  })
-                ),
-              0
-            )
-          })
-      }))
+      find: jest.fn(filter => {
+        return {
+          toArray: () =>
+            new Promise(resolve => {
+              setTimeout(
+                () =>
+                  resolve(
+                    [docs.one, docs.two, stringDoc].filter(doc => {
+                      for (const orFilter of filter.$or || [filter]) {
+                        for (const field in orFilter) {
+                          if (field === '_id') {
+                            for (const id of orFilter._id.$in) {
+                              if (id.equals && !id.equals(doc._id)) {
+                                break
+                              } else if (
+                                doc._id.equals &&
+                                !doc._id.equals(id)
+                              ) {
+                                break
+                              } else if (
+                                !id.equals &&
+                                !doc._id.equals &&
+                                id !== doc._id
+                              ) {
+                                break
+                              }
+                            }
+                          } else if (Array.isArray(doc[field])) {
+                            for (const value of orFilter[field].$in) {
+                              if (!doc[field].includes(value)) {
+                                break
+                              }
+                            }
+                          } else if (
+                            !orFilter[field].$in.includes(doc[field])
+                          ) {
+                            break
+                          }
+                        }
+                        return true
+                      }
+                      return false
+                    })
+                  ),
+                0
+              )
+            })
+        }
+      })
     }
 
     cache = new InMemoryLRUCache()
@@ -65,10 +94,11 @@ describe('createCachingMethods', () => {
   it('adds the right methods', () => {
     expect(api.findOneById).toBeDefined()
     expect(api.findManyByIds).toBeDefined()
+    expect(api.findByFields).toBeDefined()
     expect(api.deleteFromCacheById).toBeDefined()
   })
 
-  it('finds one', async () => {
+  it('finds one with ObjectId', async () => {
     const doc = await api.findOneById(docs.one._id)
     expect(doc).toBe(docs.one)
     expect(collection.find.mock.calls.length).toBe(1)
@@ -85,6 +115,62 @@ describe('createCachingMethods', () => {
 
     expect(foundDocs[0]).toBe(docs.one)
     expect(foundDocs[1]).toBe(docs.two)
+
+    expect(collection.find.mock.calls.length).toBe(1)
+  })
+
+  it('finds by field', async () => {
+    const foundDocs = await api.findByFields({ foo: 'bar' })
+
+    expect(foundDocs[0]).toBe(docs.one)
+    expect(foundDocs[1]).toBe(docs.two)
+    expect(foundDocs.length).toBe(2)
+
+    expect(collection.find.mock.calls.length).toBe(1)
+  })
+
+  it('finds by array field', async () => {
+    const foundDocs = await api.findByFields({ tags: 'bar' })
+
+    expect(foundDocs[0]).toBe(docs.one)
+    expect(foundDocs[1]).toBe(stringDoc)
+    expect(foundDocs.length).toBe(2)
+
+    expect(collection.find.mock.calls.length).toBe(1)
+  })
+
+  it('finds by mutiple fields', async () => {
+    const foundDocs = await api.findByFields({
+      tags: ['foo', 'bar'],
+      foo: 'bar'
+    })
+
+    expect(foundDocs[0]).toBe(docs.one)
+    expect(foundDocs.length).toBe(1)
+
+    expect(collection.find.mock.calls.length).toBe(1)
+  })
+
+  it(`doesn't mix filters of pending calls for different fields`, async () => {
+    const pendingDocs1 = api.findByFields({ foo: 'bar' })
+    const pendingDocs2 = api.findByFields({ tags: 'baz' })
+    const [foundDocs1, foundDocs2] = await Promise.all([
+      pendingDocs1,
+      pendingDocs2
+    ])
+
+    expect(foundDocs1[0]).toBe(docs.one)
+    expect(foundDocs1[1]).toBe(docs.two)
+    expect(foundDocs1.length).toBe(2)
+    expect(foundDocs2[0]).toBe(stringDoc)
+    expect(foundDocs2.length).toBe(1)
+
+    expect(collection.find.mock.calls.length).toBe(1)
+  })
+
+  it(`caches each value individually when finding by a single field`, async () => {
+    await api.findByFields({ tags: ['foo', 'baz'] })
+    await api.findByFields({ tags: 'foo' })
 
     expect(collection.find.mock.calls.length).toBe(1)
   })

--- a/src/cache.js
+++ b/src/cache.js
@@ -47,8 +47,8 @@ const orderDocs = fieldsArray => docs =>
   )
 
 export const createCachingMethods = ({ collection, model, cache }) => {
-  const loader = new DataLoader(JSONArray => {
-    const fieldsArray = JSONArray.map(JSON.parse)
+  const loader = new DataLoader(jsonArray => {
+    const fieldsArray = jsonArray.map(JSON.parse)
     const filterArray = fieldsArray.reduce((filterArray, fields) => {
       const existingFieldsFilter = filterArray.find(
         filter =>
@@ -96,7 +96,7 @@ export const createCachingMethods = ({ collection, model, cache }) => {
         return EJSON.parse(cacheDoc)
       }
 
-      const docs = await loader.load(JSON.stringify({ id: id }))
+      const docs = await loader.load(JSON.stringify({ id }))
       if (Number.isInteger(ttl)) {
         // https://github.com/apollographql/apollo-server/tree/master/packages/apollo-server-caching#apollo-server-caching
         cache.set(key, EJSON.stringify(docs[0]), { ttl })
@@ -153,7 +153,7 @@ export const createCachingMethods = ({ collection, model, cache }) => {
       return docs
     },
     deleteFromCacheById: async id => {
-      loader.clear(JSON.stringify({ id: id }))
+      loader.clear(JSON.stringify({ id }))
       await cache.delete(cachePrefix + idToString(id))
     }
   }

--- a/src/cache.js
+++ b/src/cache.js
@@ -110,7 +110,7 @@ export const createCachingMethods = ({ collection, model, cache }) => {
     findByFields: async (fields, { ttl } = {}) => {
       const cleanedFields = {}
 
-      Object.keys(fields).forEach(key => {
+      Object.keys(fields).sort().forEach(key => {
         if (typeof key !== 'undefined') {
           cleanedFields[key] = Array.isArray(fields[key])
             ? fields[key]

--- a/src/cache.js
+++ b/src/cache.js
@@ -112,7 +112,9 @@ export const createCachingMethods = ({ collection, model, cache }) => {
 
       Object.keys(fields).forEach(key => {
         if (typeof key !== 'undefined') {
-          cleanedFields[key] = fields[key]
+          cleanedFields[key] = Array.isArray(fields[key])
+            ? fields[key]
+            : [fields[key]]
         }
       })
 


### PR DESCRIPTION
Fixes #48

Added a findByFields method and refactored the DataLoader batch fn and tests to make it work.

This new method makes it possible to batch and cache calls for arbitrary fields on the collection.

### example:

```js

// Find by a single field
await this.findByFields({ tags: ['gaming', 'games'] }, { ttl: 1 })
// Resulting app level cache key (if the collection was "users"):
//   - 'mongo-users-{"tags":["gaming","games"]}'
// Resulting dataloader memoization cache keys:
//   - '{"tags":"gaming"}'
//   - '{"tags":"games"}'
//   .load() is called with each tag individually, so subsequent calls for either or both tags will load from memoization cache
// Resulting query:
//   - collection.find({ tags: { $in: ['gaming', 'games'] } })
// 

// Find by multiple fields
await this.findByFields({
  tags: ['gaming', 'games'],
  userName: 'testUser'
}, { ttl: 1 })
// Resulting app level cache key (if the collection was "users"):
//   - 'mongo-users-{"tags":["gaming","games"],"userName":["testUser"]}'
// Resulting dataloader memoization cache key:
//   - '{"tags":["gaming","games"],"userName":["testUser"]}'
//   Since the results need to match both the tags AND the userName, .load() is only called once with all the fields and values.
// resulting query:
//   - collection.find({
//       tags: { $in: ['gaming', 'games'] },
//       userName: { $in: ['testUser'] }
//     })

```
![apollo-datasource-mongodb-tests-passed](https://user-images.githubusercontent.com/3289505/110013315-1d8cfa00-7ce7-11eb-87ec-a9e12f4a1499.jpg)

