### PR TITLE
Fixed unintended union distribution

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,9 +7,9 @@ declare module 'apollo-datasource-mongodb' {
     Model as MongooseModel
   } from 'mongoose'
 
-  export type Collection<T> = T extends Document
+  export type Collection<T, U = MongoCollection<T>> = T extends Document
     ? MongooseCollection
-    : MongoCollection<T>
+    : U
 
   export type Model<T> = T extends Document ? MongooseModel<T> : undefined
 


### PR DESCRIPTION
Fixed issue where a union of document models would be distributed as a union of collections instead of a collection with a union of document models. As a side effect, the old type did not allow multiple document types to be inserted, updated or retrieved. 

Expected behavior should be as follows:

```typescript
interface A { ... }
interface B { ... }
interface C { ... }

type ExpectedType = Collection<A | B | C>
// MongoCollection<A | B | C>
```

Old behavior causes the type to be distributed as: 

```typescript
interface A { ... }
interface B { ... }
interface C { ... }

type OldType = Collection<A | B | C>
// MongoCollection<A> | MongoCollection<B> | MongoCollection<C>
```