### PR TITLE
Fix cache for string IDs that have exactly 12 bytes

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -10,7 +10,7 @@ const stringToId = str => {
     return str
   }
 
-  if (ObjectId.isValid(str)) {
+  if (ObjectId.isValid(str) && new ObjectId(str) === str) {
     return new ObjectId(str)
   }
 


### PR DESCRIPTION
* The method `isValid` from MongoDB just checks if a string has 12 bytes. But you could have a string ID which length=12 which would be unintentionally converted to an ObjectID which in returns causes an invalid cache miss.

Closes #60 

@lorensr Could you write a test case for this or give me a hint how to do it? I wasn't able to construct a failing one for this case with your setup... 