### PR TITLE
fix: fields array type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,7 @@ declare module 'apollo-datasource-mongodb' {
     : Collection<T>
   
   export interface Fields {
-    [fieldName: string]: string | number | boolean | [string | number | boolean]
+    [fieldName: string]: string | number | boolean | (string | number | boolean)[]
   }
 
   export interface Options {


### PR DESCRIPTION
Proper/modern array usage for typescript