### PR TITLE
Support ObjectID in findByFields Type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ declare module 'apollo-datasource-mongodb' {
   import {
     Collection as MongooseCollection,
     Document,
-    Model as MongooseModel
+    Model as MongooseModel,
   } from 'mongoose'
 
   export type Collection<T, U = MongoCollection<T>> = T extends Document
@@ -16,9 +16,14 @@ declare module 'apollo-datasource-mongodb' {
   export type ModelOrCollection<T> = T extends Document
     ? Model<T>
     : Collection<T>
-  
+
   export interface Fields {
-    [fieldName: string]: string | number | boolean | (string | number | boolean)[]
+    [fieldName: string]:
+      | string
+      | number
+      | boolean
+      | ObjectId
+      | (string | number | boolean | ObjectId)[]
   }
 
   export interface Options {


### PR DESCRIPTION
The TypeScript type for `findByFields()` didn't include `ObjectID` as a valid parameter, even though there are automated tests for it and it definitely is valid to do this in MongoDB. Update the type to reflect what's actually going on.