### PR TITLE
Support ObjectID in findByFields()

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -69,10 +69,12 @@ export const createCachingMethods = ({ collection, model, cache }) => {
         let newVals = Array.isArray(fields[fieldName])
           ? fields[fieldName]
           : [fields[fieldName]]
-        if (docFieldName === '_id') newVals = newVals.map(stringToId)
+
         filter[docFieldName].$in = [
           ...filter[docFieldName].$in,
-          ...newVals.filter(val => !filter[docFieldName].$in.includes(val))
+          ...newVals
+            .map(stringToId)
+            .filter(val => !filter[docFieldName].$in.includes(val))
         ]
       }
       if (existingFieldsFilter) return filterArray


### PR DESCRIPTION
The `findByFields()` method could not find documents by a given ObjectID because the `stringToId()` function was only being run when querying for a field named `_id`. Since any MongoDB field could in theory contain an ObjectID, this broke queries looking for ObjectIDs in arbitrary fields. To resolve this, remove the condition testing for the field name of `_id` and run `stringToId()` on all values. This will validate whether a given String value is actually in the ObjectID format before proceeding, so it seems safe to apply everywhere.

The tests passed locally when I changed this implementation, which means there is probably something wrong with the mocks in the `cache.test.js`...might be something to look into. This at least confirmed my belief as I was observing very different behavior in the real world than what the tests would have suggested.

Fixes #65