### PR TITLE
fix: using mongoose Document model interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,15 +7,15 @@ declare module 'apollo-datasource-mongodb' {
     Model as MongooseModel,
   } from 'mongoose'
 
-  export type Collection<T, U = MongoCollection<T>> = T extends Document
+  export type Collection<T, U = MongoCollection<T>> = T extends MongoCollection
     ? MongooseCollection
     : U
 
-  export type Model<T, U = MongooseModel<T>> = T extends Document
+  export type Model<T, U = MongooseModel<T>> = T extends MongosseModel
     ? U
     : undefined
 
-  export type ModelOrCollection<T, U = Model<T>> = T extends Document
+  export type ModelOrCollection<T, U = Model<T>> = T extends Model
     ? U
     : Collection<T>
 


### PR DESCRIPTION
The extended mongoose Document will be dropped in the next major version.

> We strongly recommend against using this approach, its support will be dropped in the next major version as it causes major performance issues. Many Mongoose TypeScript codebases use the below approach. - https://mongoosejs.com/docs/typescript.html#using-extends-document

It will correctly infer the model or collection TypeScript types when mongoose.

## Interface
![Captura de Tela 2022-06-19 às 20 40 56](https://user-images.githubusercontent.com/49658066/174504593-ff4a891e-5d54-4bc5-9675-02c6ad80ba13.png)

## Before
![Captura de Tela 2022-06-19 às 20 41 30](https://user-images.githubusercontent.com/49658066/174504621-a6a4710a-bd60-4510-91f3-41cc8037b29b.png)

## After
![Captura de Tela 2022-06-19 às 20 39 51](https://user-images.githubusercontent.com/49658066/174504569-0ed7746f-e075-4c7a-8a2f-6324e452848d.png)


