### PR TITLE
Force mongoose .lean()

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -135,7 +135,7 @@ export const createCachingMethods = ({ collection, model, cache }) => {
     log('filter: ', filter)
 
     const findPromise = model
-      ? model.find(filter).exec()
+      ? model.find(filter).lean()
       : collection.find(filter).toArray()
 
     const results = await findPromise


### PR DESCRIPTION
Added .lean() on mongoose Queries to avoid mongoose hydration and speedup performance.
It solves that bug when setting TTL from Mongoose Models