### PR TITLE
fix: Always use lean Mongoose documents

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,8 +5,7 @@ declare module 'apollo-datasource-mongodb' {
     Collection as MongooseCollection,
     Document,
     Model as MongooseModel,
-    LeanDocument,
-    MongooseDocument
+    LeanDocument
   } from 'mongoose'
 
   export type Collection<T, U = MongoCollection<T>> = T extends Document
@@ -30,13 +29,11 @@ declare module 'apollo-datasource-mongodb' {
       | (string | number | boolean | ObjectId)[]
   }
 
-  type MongooseDocumentOrMongoCollection<T> = MongoCollection<T> | MongooseDocument
-
   export interface Options {
     ttl: number
   }
 
-  export class MongoDataSource<TData extends MongooseDocumentOrMongoCollection<any>, TContext = any> extends DataSource<
+  export class MongoDataSource<TData, TContext = any> extends DataSource<
     TContext
   > {
     protected context: TContext

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,8 @@ declare module 'apollo-datasource-mongodb' {
     Collection as MongooseCollection,
     Document,
     Model as MongooseModel,
+    LeanDocument,
+    MongooseDocument
   } from 'mongoose'
 
   export type Collection<T, U = MongoCollection<T>> = T extends Document
@@ -28,11 +30,13 @@ declare module 'apollo-datasource-mongodb' {
       | (string | number | boolean | ObjectId)[]
   }
 
+  type MongooseDocumentOrMongoCollection<T> = MongoCollection<T> | MongooseDocument
+
   export interface Options {
     ttl: number
   }
 
-  export class MongoDataSource<TData, TContext = any> extends DataSource<
+  export class MongoDataSource<TData extends MongooseDocumentOrMongoCollection<any>, TContext = any> extends DataSource<
     TContext
   > {
     protected context: TContext
@@ -44,17 +48,17 @@ declare module 'apollo-datasource-mongodb' {
     findOneById(
       id: ObjectId | string,
       options?: Options
-    ): Promise<TData | null | undefined>
+    ): Promise<LeanDocument<TData> | null | undefined>
 
     findManyByIds(
       ids: (ObjectId | string)[],
       options?: Options
-    ): Promise<(TData | null | undefined)[]>
+    ): Promise<(LeanDocument<TData> | null | undefined)[]>
 
     findByFields(
       fields: Fields,
       options?: Options
-    ): Promise<(TData | null | undefined)[]>
+    ): Promise<(LeanDocument<TData> | null | undefined)[]>
 
     deleteFromCacheById(id: ObjectId | string): Promise<void>
     deleteFromCacheByFields(fields: Fields): Promise<void>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14463,6 +14463,15 @@
         "strip-ansi": "^5.1.0"
       }
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "strip-ansi": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",

--- a/src/__tests__/datasource.test.js
+++ b/src/__tests__/datasource.test.js
@@ -107,7 +107,7 @@ describe('Mongoose', () => {
     users.initialize()
     const user = await users.findOneById(alice._id)
     expect(user.name).toBe('Alice')
-    expect(user.id).toBe(alice._id.toString())
+    expect(user._id.toString()).toBe(alice._id.toString())
   })
 
   test('Data Source with Collection', async () => {

--- a/src/cache.js
+++ b/src/cache.js
@@ -135,7 +135,10 @@ export const createCachingMethods = ({ collection, model, cache }) => {
     log('filter: ', filter)
 
     const findPromise = model
-      ? model.find(filter).exec()
+      ? model
+          .find(filter)
+          .lean()
+          .exec()
       : collection.find(filter).toArray()
 
     const results = await findPromise


### PR DESCRIPTION
With hydrated Mongoose documents they aren't serializable.
Therefore caching can't be used, as it serializes the documents.

See https://github.com/GraphQLGuide/apollo-datasource-mongodb/issues/74 for why this is needed for Mongoose documents.