### PR TITLE
Apollo-server-4-upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 [![npm version](https://badge.fury.io/js/apollo-datasource-mongodb.svg)](https://www.npmjs.com/package/apollo-datasource-mongodb)
 
-Apollo [data source](https://www.apollographql.com/docs/apollo-server/features/data-sources) for MongoDB
+MongoDB [data source](https://www.apollographql.com/docs/apollo-server/data/fetching-data) for Apollo Server 4
 
 ```
-npm i apollo-datasource-mongodb
+npm i apollo-mongo-datasource
 ```
 
-This package uses [DataLoader](https://github.com/graphql/dataloader) for batching and per-request memoization caching. It also optionally (if you provide a `ttl`) does shared application-level caching (using either the default Apollo `InMemoryLRUCache` or the [cache you provide to ApolloServer()](https://www.apollographql.com/docs/apollo-server/features/data-sources#using-memcachedredis-as-a-cache-storage-backend)). It does this for the following methods:
+This package uses [DataLoader](https://github.com/graphql/dataloader) for batching and per-request memoization caching. It also optionally (if you provide a `ttl`) does shared application-level caching (using either the default Apollo `InMemoryLRUCache` or the [cache you provide to ApolloServer()](https://www.apollographql.com/docs/apollo-server/performance/cache-backends#configuring-external-caching)). It does this for the following methods:
 
 - [`findOneById(id, options)`](#findonebyid)
 - [`findManyByIds(ids, options)`](#findmanybyids)
 - [`findByFields(fields, options)`](#findbyfields)
 
-
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
 **Contents:**
 
 - [Usage](#usage)
@@ -31,7 +31,6 @@ This package uses [DataLoader](https://github.com/graphql/dataloader) for batchi
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-
 ## Usage
 
 ### Basic
@@ -41,7 +40,7 @@ The basic setup is subclassing `MongoDataSource`, passing your collection or Mon
 `data-sources/Users.js`
 
 ```js
-import { MongoDataSource } from 'apollo-datasource-mongodb'
+import { MongoDataSource } from 'apollo-mongo-datasource'
 
 export default class Users extends MongoDataSource {
   getUser(userId) {
@@ -54,6 +53,8 @@ and:
 
 ```js
 import { MongoClient } from 'mongodb'
+import { ApolloServer } from '@apollo/server'
+import { startStandaloneServer } from '@apollo/server/standalone'
 
 import Users from './data-sources/Users.js'
 
@@ -62,20 +63,28 @@ client.connect()
 
 const server = new ApolloServer({
   typeDefs,
-  resolvers,
-  dataSources: () => ({
-    users: new Users(client.db().collection('users'))
-    // OR
-    // users: new Users(UserModel)
-  })
+  resolvers
+})
+
+const { url } = await startStandaloneServer(server, {
+  context: async ({ req }) => ({
+    dataSources: {
+      users: new Users({ modelOrCollection: client.db().collection('users') })
+      // OR
+      // users: new Users({ modelOrCollection: UserModel })
+    }
+  }),
 })
 ```
 
-Inside the data source, the collection is available at `this.collection` (e.g. `this.collection.update({_id: 'foo, { $set: { name: 'me' }}})`). The model (if you're using Mongoose) is available at `this.model` (`new this.model({ name: 'Alice' })`). The request's context is available at `this.context`. For example, if you put the logged-in user's ID on context as `context.currentUserId`:
+Inside the data source, the collection is available at `this.collection` (e.g. `this.collection.update({_id: 'foo, { $set: { name: 'me' }}})`). The model (if you're using Mongoose) is available at `this.model` (`new this.model({ name: 'Alice' })`). In Apollo Server 3, the context was automatically handled by the abstract DataSource class from apollo-datasource. This package has been deprecated, so the DataSource class has been removed from this package, as well as the initialize method. By default, the API classes you create will not have access to the context. You can either choose to add the data that your API class needs as private members of the class, or you can add the entire context as a member of the class if you wish. All you need to do is add the field to the options argument of the constructor and call super. Then, the request's context is available at `this.context`. For example, if you put the logged-in user's ID on context as `context.currentUserId`:
 
 ```js
 class Users extends MongoDataSource {
-  ...
+  constructor(options) {
+    super(options)
+    this.context = options.context
+  }
 
   async getPrivateUserData(userId) {
     const isAuthorized = this.context.currentUserId === userId
@@ -87,12 +96,34 @@ class Users extends MongoDataSource {
 }
 ```
 
-If you want to implement an initialize method, it must call the parent method:
+and you would instantiate the Users class like this
 
 ```js
-class Users extends MongoDataSource {
-  initialize(config) {
-    super.initialize(config)
+...
+const server = new ApolloServer({
+  typeDefs,
+  resolvers
+})
+
+const { url } = await startStandaloneServer(server, {
+  context: async ({ req }) => ({
+    dataSources: {
+      users: new Users({ modelOrCollection: UserModel, context: { currentUserId: '123' } })
+    }
+  }),
+});
+```
+
+If you want your data source to have access to the entire context, you need to create a Context class so the context can refer to itself as this in the constructor for the data source.
+See [dataSources](https://www.apollographql.com/docs/apollo-server/migration/#datasources) for more information regarding how data sources changed from Apollo Server 3 to Apollo Server 4.
+
+```js
+class Context {
+  constructor() {
+    this.dataSources = {
+      users: new Users({ modelOrCollection: UserModel, context: this })
+    },
+    this.currentUserId = '123',
     ...
   }
 }
@@ -119,7 +150,8 @@ class Posts extends MongoDataSource {
 
 const resolvers = {
   Post: {
-    author: (post, _, { dataSources: { users } }) => users.getUser(post.authorId)
+    author: (post, _, { dataSources: { users } }) =>
+      users.getUser(post.authorId)
   },
   User: {
     posts: (user, _, { dataSources: { posts } }) => posts.getPosts(user.postIds)
@@ -128,11 +160,16 @@ const resolvers = {
 
 const server = new ApolloServer({
   typeDefs,
-  resolvers,
-  dataSources: () => ({
-    users: new Users(db.collection('users')),
-    posts: new Posts(db.collection('posts'))
-  })
+  resolvers
+})
+
+const { url } = await startStandaloneServer(server, {
+  context: async ({ req }) => ({
+    dataSources: {
+      users: new Users({ modelOrCollection: db.collection('users') }),
+      posts: new Posts({ modelOrCollection: db.collection('posts') })
+    }
+  }),
 })
 ```
 
@@ -150,11 +187,14 @@ class Users extends MongoDataSource {
 
   updateUserName(userId, newName) {
     this.deleteFromCacheById(userId)
-    return this.collection.updateOne({
-      _id: userId
-    }, {
-      $set: { name: newName }
-    })
+    return this.collection.updateOne(
+      {
+        _id: userId
+      },
+      {
+        $set: { name: newName }
+      }
+    )
   }
 }
 
@@ -173,12 +213,12 @@ Here we also call [`deleteFromCacheById()`](#deletefromcachebyid) to remove the 
 
 ### TypeScript
 
-Since we are using a typed language, we want the provided methods to be correctly typed as well. This requires us to make the `MongoDataSource` class polymorphic. It requires 1-2 template arguments. The first argument is the type of the document in our collection. The second argument is the type of context in our GraphQL server, which defaults to `any`. For example:
+Since we are using a typed language, we want the provided methods to be correctly typed as well. This requires us to make the `MongoDataSource` class polymorphic. It requires 1-2 template arguments. The first argument is the type of the document in our collection. The second argument is the type of context in our GraphQL server, which defaults to `any`. We can choose to either pass the necessary data from context to the data source by field, or give the data source class access to the entire context. For example:
 
 `data-sources/Users.ts`
 
 ```ts
-import { MongoDataSource } from 'apollo-datasource-mongodb'
+import { MongoDataSource } from 'apollo-mongo-datasource'
 import { ObjectId } from 'mongodb'
 
 interface UserDocument {
@@ -195,6 +235,78 @@ interface Context {
 }
 
 export default class Users extends MongoDataSource<UserDocument, Context> {
+  protected loggedInUser: UserDocument;
+
+  constructor(options: { loggedInUser: UserDocument } & MongoDataSourceConfig<TData>) {
+    super(options);
+    this.loggedInUser = options.loggedInUser;
+  }
+
+  getUser(userId) {
+    // this.loggedInUser has type `UserDocument` as defined above
+    // this.findOneById has type `(id: ObjectId) => Promise<UserDocument | null | undefined>`
+    return this.findOneById(userId)
+  }
+}
+```
+
+and:
+
+```ts
+import { MongoClient } from 'mongodb'
+
+import Users from './data-sources/Users.ts'
+
+const client = new MongoClient('mongodb://localhost:27017/test')
+client.connect()
+
+const server = new ApolloServer({
+  typeDefs,
+  resolvers
+})
+
+const { url } = await startStandaloneServer(server, {
+  context: async ({ req }) => {
+    const loggedInUser = getLoggedInUser(req); // this function does not exist, just for demo purposes
+    return {
+      loggedInUser,
+      dataSources: {
+        users: new Users({ modelOrCollection: client.db().collection('users'), loggedInUser})
+      },
+    };
+  },
+});
+```
+
+You can also opt to pass the entire context into your data source class. You can do so by adding a protected context member 
+to your data source class and modifying to options argument of the constructor to add a field for the context. Then, call super and
+assign the context to the member field on your data source class.
+
+```ts
+import { MongoDataSource } from 'apollo-mongo-datasource'
+import { ObjectId } from 'mongodb'
+
+interface UserDocument {
+  _id: ObjectId
+  username: string
+  password: string
+  email: string
+  interests: [string]
+}
+
+// This is optional
+interface Context {
+  loggedInUser: UserDocument
+}
+
+export default class Users extends MongoDataSource<UserDocument, Context> {
+  protected context: Context;
+
+  constructor(options: { context: Context } & MongoDataSourceConfig<TData>) {
+    super(options);
+    this.context = options.context;
+  }
+
   getUser(userId) {
     // this.context has type `Context` as defined above
     // this.findOneById has type `(id: ObjectId) => Promise<UserDocument | null | undefined>`
@@ -215,14 +327,22 @@ client.connect()
 
 const server = new ApolloServer({
   typeDefs,
-  resolvers,
-  dataSources: () => ({
-    users: new Users(client.db().collection('users'))
-    // OR
-    // users: new Users(UserModel)
-  })
+  resolvers
 })
+
+const { url } = await startStandaloneServer(server, {
+  context: async ({ req }) => {
+    const loggedInUser = getLoggedInUser(req); // this function does not exist, just for demo purposes
+    return {
+      loggedInUser,
+      dataSources: {
+        users: new Users({ modelOrCollection: client.db().collection('users'), context: this })
+      },
+    };
+  },
+});
 ```
+
 
 ## API
 
@@ -293,3 +413,6 @@ Deletes a document from the cache that was fetched with `findOneById` or `findMa
 `this.deleteFromCacheByFields(fields)`
 
 Deletes a document from the cache that was fetched with `findByFields`. Fields should be passed in exactly the same way they were used to find with.
+
+## Forked and extended from
+- [The GraphQLGuide's Apollo data source for MongoDB](https://github.com/GraphQLGuide/apollo-datasource-mongodb)

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare module 'apollo-datasource-mongodb' {
-  import { DataSource } from 'apollo-datasource'
+  import { KeyValueCache } from '@apollo/utils.keyvaluecache'
   import { Collection as MongoCollection, ObjectId } from 'mongodb'
   import {
     Collection as MongooseCollection,
@@ -32,14 +32,16 @@ declare module 'apollo-datasource-mongodb' {
     ttl: number
   }
 
-  export class MongoDataSource<TData, TContext = any> extends DataSource<
-    TContext
-  > {
-    protected context: TContext
+  export interface MongoDataSourceConfig<TData> {
+    modelOrCollection: ModelOrCollection<TData>
+    cache?: KeyValueCache<TData>
+  }
+
+  export class MongoDataSource<TData> {
     protected collection: Collection<TData>
     protected model: Model<TData>
 
-    constructor(modelOrCollection: ModelOrCollection<TData>)
+    constructor(options: MongoDataSourceConfig<TData>)
 
     findOneById(
       id: ObjectId | string,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,19 @@
 {
-  "name": "apollo-datasource-mongodb",
+  "name": "apollo-mongo-datasource",
   "version": "0.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "apollo-datasource-mongodb",
-      "version": "0.5.3",
+      "name": "apollo-mongo-datasource",
+      "version": "0.5.4",
       "license": "MIT",
       "dependencies": {
+        "@apollo/utils.keyvaluecache": "^3.0.0",
         "@types/mongodb": "^3.5.27",
-        "apollo-datasource": "^0.3.1",
-        "apollo-server-caching": "^0.3.1",
         "apollo-server-errors": "^2.4.1",
         "bson": "^4.1.0",
-        "dataloader": "^1.4.0",
-        "mongoose": "^5.13.8"
+        "dataloader": "^1.4.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.10.3",
@@ -25,12 +23,36 @@
         "graphql": "^14.6.0",
         "jest": "^24.9.0",
         "mongodb": "^3.5.9",
+        "mongoose": "^5.13.8",
         "prettier": "^1.19.1",
         "release": "^6.3.0",
         "waait": "^1.0.5"
       },
       "engines": {
         "node": ">=8"
+      },
+      "peerDependencies": {
+        "mongoose": "*"
+      }
+    },
+    "node_modules/@apollo/utils.keyvaluecache": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-3.0.0.tgz",
+      "integrity": "sha512-tgMpuYU3KvYevCNG+hTemSuSQtZaaWcHGnF/h2ERcw8bodFmbwVsG/jHlhdT0ChlRXgBIqMUFXbQtF6epy+AKA==",
+      "dependencies": {
+        "@apollo/utils.logger": "^3.0.0",
+        "lru-cache": "^9.0.3"
+      },
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
+    "node_modules/@apollo/utils.logger": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-3.0.0.tgz",
+      "integrity": "sha512-M8V8JOTH0F2qEi+ktPfw4RL7MvUycDfKp7aEap2eWXfL5SqWHN6jTLbj5f5fj1cceHpyaUSOZlvlaaryaxZAmg==",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@babel/cli": {
@@ -1577,41 +1599,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/apollo-datasource": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.3.1.tgz",
-      "integrity": "sha512-qdEUeonc9pPZvYwXK36h2NZoT7Pddmy0HYOzdV0ON5pcG1YtNmUyyYi83Q60V5wTWjuaCjyJ9hOY6wr0BMvQuA==",
-      "dependencies": {
-        "apollo-server-caching": "0.3.1",
-        "apollo-server-env": "2.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/apollo-server-caching": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.3.1.tgz",
-      "integrity": "sha512-mfxzikYXbB/OoEms77AGYwRh7FF3Oim5v5XWAL+VL49FrkbZt5lopVa4bABi7Mz8Nt3Htl9EBJN8765s/yh8IA==",
-      "dependencies": {
-        "lru-cache": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/apollo-server-env": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-2.2.0.tgz",
-      "integrity": "sha512-wjJiI5nQWPBpNmpiLP389Ezpstp71szS6DHAeTgYLb/ulCw3CTuuA+0/E1bsThVWiQaDeHZE0sE3yI8q2zrYiA==",
-      "dependencies": {
-        "node-fetch": "^2.1.2",
-        "util.promisify": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/apollo-server-errors": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.4.1.tgz",
@@ -1985,6 +1972,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
       "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "dev": true,
       "dependencies": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -1993,7 +1981,8 @@
     "node_modules/bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "dev": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2521,7 +2510,8 @@
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "node_modules/cross-spawn": {
       "version": "6.0.5",
@@ -2681,6 +2671,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
       "dependencies": {
         "object-keys": "^1.0.12"
       },
@@ -2761,6 +2752,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
       "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -2848,6 +2840,7 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
       "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "dev": true,
       "dependencies": {
         "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",
@@ -2864,6 +2857,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
       "dependencies": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -3423,7 +3417,8 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.1",
@@ -3775,6 +3770,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -3804,6 +3800,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -4012,7 +4009,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -4140,6 +4138,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
       "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -4184,6 +4183,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -4325,6 +4325,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
       "dependencies": {
         "has": "^1.0.1"
       },
@@ -4354,6 +4355,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.0"
       },
@@ -4388,7 +4390,8 @@
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -5198,7 +5201,8 @@
     "node_modules/kareem": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.2.tgz",
-      "integrity": "sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ=="
+      "integrity": "sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ==",
+      "dev": true
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -5359,11 +5363,11 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dependencies": {
-        "yallist": "^3.0.2"
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.1.tgz",
+      "integrity": "sha512-65/Jky17UwSb0BuB9V+MyDpsOtXKmYwzhyl+cOa9XUiI4uV2Ouy/2voFP3+al0BjZbJgMBD8FojMpAf+Z+qn4A==",
+      "engines": {
+        "node": "14 || >=16.14"
       }
     },
     "node_modules/make-dir": {
@@ -5413,6 +5417,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "dev": true,
       "optional": true
     },
     "node_modules/merge-stream": {
@@ -5543,6 +5548,7 @@
       "version": "3.6.11",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.11.tgz",
       "integrity": "sha512-4Y4lTFHDHZZdgMaHmojtNAlqkvddX2QQBEN0K//GzxhGwlI9tZ9R0vhbjr1Decw+TF7qK0ZLjQT292XgHRRQgw==",
+      "dev": true,
       "dependencies": {
         "bl": "^2.2.1",
         "bson": "^1.1.4",
@@ -5581,6 +5587,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
       "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg==",
+      "dev": true,
       "engines": {
         "node": ">=0.6.19"
       }
@@ -5589,6 +5596,7 @@
       "version": "5.13.8",
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.13.8.tgz",
       "integrity": "sha512-z3d+qei9Dem/LxRcJi0cdGPKzQnYk71oHEsEfYm17JA/vLiAbJiGuBS2hW7vkd9afkPAqu3KsPZh2ax0c5iPQw==",
+      "dev": true,
       "dependencies": {
         "@types/mongodb": "^3.5.27",
         "bson": "^1.1.4",
@@ -5616,6 +5624,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
       "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==",
+      "dev": true,
       "engines": {
         "node": ">=0.6.19"
       }
@@ -5624,6 +5633,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
       "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==",
+      "dev": true,
       "peerDependencies": {
         "mongoose": "*"
       }
@@ -5631,12 +5641,14 @@
     "node_modules/mongoose/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/mongoose/node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5656,6 +5668,7 @@
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.3.tgz",
       "integrity": "sha512-eb9rRvhDltXVNL6Fxd2zM9D4vKBxjVVQNLNijlj7uoXUy19zNDsIif5zR+pWmPCWNKwAtqyo4JveQm4nfD5+eA==",
+      "dev": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -5664,6 +5677,7 @@
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.5.tgz",
       "integrity": "sha512-VjOKHHgU84wij7IUoZzFRU07IAxd5kWJaDmyUzQlbjHjyoeK5TNeeo8ZsFDtTYnSgpW6n/nMNIHvE3u8Lbrf4A==",
+      "dev": true,
       "dependencies": {
         "bluebird": "3.5.1",
         "debug": "3.1.0",
@@ -5679,6 +5693,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -5695,7 +5710,8 @@
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "node_modules/mute-stream": {
       "version": "0.0.7",
@@ -5748,6 +5764,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
       "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==",
+      "dev": true,
       "engines": {
         "node": "4.x || >=6.0.0"
       }
@@ -5880,6 +5897,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
       "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -5915,6 +5933,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "dev": true,
       "dependencies": {
         "define-properties": "^1.1.2",
         "es-abstract": "^1.5.1"
@@ -5972,6 +5991,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.3.tgz",
       "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -6381,7 +6401,8 @@
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "node_modules/promise-polyfill": {
       "version": "6.1.0",
@@ -6503,6 +6524,7 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -6590,7 +6612,8 @@
     "node_modules/regexp-clone": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
-      "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw=="
+      "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw==",
+      "dev": true
     },
     "node_modules/regexpu-core": {
       "version": "4.7.0",
@@ -6957,7 +6980,8 @@
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "node_modules/safe-regex": {
       "version": "1.1.0",
@@ -7001,6 +7025,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
       "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
@@ -7087,7 +7112,8 @@
     "node_modules/sift": {
       "version": "13.5.2",
       "resolved": "https://registry.npmjs.org/sift/-/sift-13.5.2.tgz",
-      "integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA=="
+      "integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA==",
+      "dev": true
     },
     "node_modules/signal-exit": {
       "version": "3.0.3",
@@ -7113,7 +7139,8 @@
     "node_modules/sliced": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
-      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
+      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E=",
+      "dev": true
     },
     "node_modules/snapdragon": {
       "version": "0.8.2",
@@ -7297,6 +7324,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
@@ -7426,6 +7454,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -7954,12 +7983,14 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "node_modules/util.promisify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
       "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+      "dev": true,
       "dependencies": {
         "define-properties": "^1.1.2",
         "object.getownpropertydescriptors": "^2.0.3"
@@ -8169,11 +8200,6 @@
       "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
       "dev": true
     },
-    "node_modules/yallist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
-    },
     "node_modules/yargs": {
       "version": "13.3.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
@@ -8204,6 +8230,20 @@
     }
   },
   "dependencies": {
+    "@apollo/utils.keyvaluecache": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-3.0.0.tgz",
+      "integrity": "sha512-tgMpuYU3KvYevCNG+hTemSuSQtZaaWcHGnF/h2ERcw8bodFmbwVsG/jHlhdT0ChlRXgBIqMUFXbQtF6epy+AKA==",
+      "requires": {
+        "@apollo/utils.logger": "^3.0.0",
+        "lru-cache": "^9.0.3"
+      }
+    },
+    "@apollo/utils.logger": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-3.0.0.tgz",
+      "integrity": "sha512-M8V8JOTH0F2qEi+ktPfw4RL7MvUycDfKp7aEap2eWXfL5SqWHN6jTLbj5f5fj1cceHpyaUSOZlvlaaryaxZAmg=="
+    },
     "@babel/cli": {
       "version": "7.10.3",
       "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.10.3.tgz",
@@ -9664,32 +9704,6 @@
         }
       }
     },
-    "apollo-datasource": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.3.1.tgz",
-      "integrity": "sha512-qdEUeonc9pPZvYwXK36h2NZoT7Pddmy0HYOzdV0ON5pcG1YtNmUyyYi83Q60V5wTWjuaCjyJ9hOY6wr0BMvQuA==",
-      "requires": {
-        "apollo-server-caching": "0.3.1",
-        "apollo-server-env": "2.2.0"
-      }
-    },
-    "apollo-server-caching": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.3.1.tgz",
-      "integrity": "sha512-mfxzikYXbB/OoEms77AGYwRh7FF3Oim5v5XWAL+VL49FrkbZt5lopVa4bABi7Mz8Nt3Htl9EBJN8765s/yh8IA==",
-      "requires": {
-        "lru-cache": "^5.0.0"
-      }
-    },
-    "apollo-server-env": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-2.2.0.tgz",
-      "integrity": "sha512-wjJiI5nQWPBpNmpiLP389Ezpstp71szS6DHAeTgYLb/ulCw3CTuuA+0/E1bsThVWiQaDeHZE0sE3yI8q2zrYiA==",
-      "requires": {
-        "node-fetch": "^2.1.2",
-        "util.promisify": "^1.0.0"
-      }
-    },
     "apollo-server-errors": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.4.1.tgz",
@@ -9992,6 +10006,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
       "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "dev": true,
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -10000,7 +10015,8 @@
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -10466,7 +10482,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -10604,6 +10621,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -10664,7 +10682,8 @@
     "denque": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+      "dev": true
     },
     "detect-newline": {
       "version": "2.1.0",
@@ -10740,6 +10759,7 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
       "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",
@@ -10753,6 +10773,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -11195,7 +11216,8 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "gensync": {
       "version": "1.0.0-beta.1",
@@ -11486,6 +11508,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -11505,7 +11528,8 @@
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
     },
     "has-to-string-tag-x": {
       "version": "1.4.1",
@@ -11680,7 +11704,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "1.3.8",
@@ -11790,7 +11815,8 @@
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
     },
     "is-ci": {
       "version": "2.0.0",
@@ -11824,7 +11850,8 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -11931,6 +11958,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -11951,6 +11979,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
       "requires": {
         "has-symbols": "^1.0.0"
       }
@@ -11976,7 +12005,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -12651,7 +12681,8 @@
     "kareem": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.2.tgz",
-      "integrity": "sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ=="
+      "integrity": "sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ==",
+      "dev": true
     },
     "kind-of": {
       "version": "6.0.3",
@@ -12775,12 +12806,9 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "requires": {
-        "yallist": "^3.0.2"
-      }
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.1.tgz",
+      "integrity": "sha512-65/Jky17UwSb0BuB9V+MyDpsOtXKmYwzhyl+cOa9XUiI4uV2Ouy/2voFP3+al0BjZbJgMBD8FojMpAf+Z+qn4A=="
     },
     "make-dir": {
       "version": "2.1.0",
@@ -12820,6 +12848,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "dev": true,
       "optional": true
     },
     "merge-stream": {
@@ -12925,6 +12954,7 @@
       "version": "3.6.11",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.11.tgz",
       "integrity": "sha512-4Y4lTFHDHZZdgMaHmojtNAlqkvddX2QQBEN0K//GzxhGwlI9tZ9R0vhbjr1Decw+TF7qK0ZLjQT292XgHRRQgw==",
+      "dev": true,
       "requires": {
         "bl": "^2.2.1",
         "bson": "^1.1.4",
@@ -12937,7 +12967,8 @@
         "bson": {
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
-          "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
+          "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg==",
+          "dev": true
         }
       }
     },
@@ -12945,6 +12976,7 @@
       "version": "5.13.8",
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.13.8.tgz",
       "integrity": "sha512-z3d+qei9Dem/LxRcJi0cdGPKzQnYk71oHEsEfYm17JA/vLiAbJiGuBS2hW7vkd9afkPAqu3KsPZh2ax0c5iPQw==",
+      "dev": true,
       "requires": {
         "@types/mongodb": "^3.5.27",
         "bson": "^1.1.4",
@@ -12964,35 +12996,41 @@
         "bson": {
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
-          "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg=="
+          "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==",
+          "dev": true
         },
         "mongoose-legacy-pluralize": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
           "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==",
+          "dev": true,
           "requires": {}
         },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         },
         "safe-buffer": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
         }
       }
     },
     "mpath": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.3.tgz",
-      "integrity": "sha512-eb9rRvhDltXVNL6Fxd2zM9D4vKBxjVVQNLNijlj7uoXUy19zNDsIif5zR+pWmPCWNKwAtqyo4JveQm4nfD5+eA=="
+      "integrity": "sha512-eb9rRvhDltXVNL6Fxd2zM9D4vKBxjVVQNLNijlj7uoXUy19zNDsIif5zR+pWmPCWNKwAtqyo4JveQm4nfD5+eA==",
+      "dev": true
     },
     "mquery": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.5.tgz",
       "integrity": "sha512-VjOKHHgU84wij7IUoZzFRU07IAxd5kWJaDmyUzQlbjHjyoeK5TNeeo8ZsFDtTYnSgpW6n/nMNIHvE3u8Lbrf4A==",
+      "dev": true,
       "requires": {
         "bluebird": "3.5.1",
         "debug": "3.1.0",
@@ -13005,6 +13043,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -13020,7 +13059,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -13069,7 +13109,8 @@
     "node-fetch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
-      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
+      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==",
+      "dev": true
     },
     "node-int64": {
       "version": "0.4.0",
@@ -13176,7 +13217,8 @@
     "object-keys": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
-      "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg=="
+      "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -13203,6 +13245,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "es-abstract": "^1.5.1"
@@ -13247,7 +13290,8 @@
     "optional-require": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.3.tgz",
-      "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA=="
+      "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA==",
+      "dev": true
     },
     "optionator": {
       "version": "0.8.3",
@@ -13552,7 +13596,8 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "promise-polyfill": {
       "version": "6.1.0",
@@ -13653,6 +13698,7 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -13728,7 +13774,8 @@
     "regexp-clone": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
-      "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw=="
+      "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw==",
+      "dev": true
     },
     "regexpu-core": {
       "version": "4.7.0",
@@ -14024,7 +14071,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -14062,6 +14110,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
       "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "dev": true,
       "optional": true,
       "requires": {
         "sparse-bitfield": "^3.0.3"
@@ -14132,7 +14181,8 @@
     "sift": {
       "version": "13.5.2",
       "resolved": "https://registry.npmjs.org/sift/-/sift-13.5.2.tgz",
-      "integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA=="
+      "integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA==",
+      "dev": true
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -14155,7 +14205,8 @@
     "sliced": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
-      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
+      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E=",
+      "dev": true
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -14311,6 +14362,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "dev": true,
       "optional": true,
       "requires": {
         "memory-pager": "^1.0.2"
@@ -14421,6 +14473,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -14850,12 +14903,14 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "util.promisify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
       "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "object.getownpropertydescriptors": "^2.0.3"
@@ -15045,11 +15100,6 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
       "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
       "dev": true
-    },
-    "yallist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
     },
     "yargs": {
       "version": "13.3.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "apollo-datasource-mongodb",
+  "name": "apollo-mongo-datasource",
   "version": "0.5.4",
-  "description": "Apollo data source for MongoDB",
+  "description": "MongoDB data source for Apollo Server 4",
   "main": "dist/index.js",
   "types": "index.d.ts",
   "scripts": {
@@ -17,9 +17,8 @@
     "node": ">=8"
   },
   "dependencies": {
+    "@apollo/utils.keyvaluecache": "^3.0.0",
     "@types/mongodb": "^3.5.27",
-    "apollo-datasource": "^0.3.1",
-    "apollo-server-caching": "^0.3.1",
     "apollo-server-errors": "^2.4.1",
     "bson": "^4.1.0",
     "dataloader": "^1.4.0"
@@ -40,16 +39,16 @@
     "release": "^6.3.0",
     "waait": "^1.0.5"
   },
-  "homepage": "https://github.com/GraphQLGuide/apollo-datasource-mongodb",
+  "homepage": "https://github.com/nnoce14/apollo-mongo-datasource",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/GraphQLGuide/apollo-datasource-mongodb"
+    "url": "git+https://github.com/nnoce14/apollo-mongo-datasource"
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/GraphQLGuide/apollo-datasource-mongodb/issues"
+    "url": "https://github.com/nnoce14/apollo-mongo-datasource/issues"
   },
-  "author": "Loren Sands-Ramshaw <loren@graphql.guide> (https://graphql.guide)",
+  "author": "Nick Noce <nnoce12@gmail.com>",
   "keywords": [
     "apollo",
     "datasource",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-mongo-datasource",
-  "version": "0.5.4",
+  "version": "1.0.0",
   "description": "MongoDB data source for Apollo Server 4",
   "main": "dist/index.js",
   "types": "index.d.ts",

--- a/src/__tests__/cache.test.js
+++ b/src/__tests__/cache.test.js
@@ -1,4 +1,4 @@
-import { InMemoryLRUCache } from 'apollo-server-caching'
+import { InMemoryLRUCache } from '@apollo/utils.keyvaluecache'
 import wait from 'waait'
 import { ObjectId } from 'mongodb'
 import { EJSON } from 'bson'

--- a/src/__tests__/datasource.test.js
+++ b/src/__tests__/datasource.test.js
@@ -4,13 +4,13 @@ import mongoose, { Schema, model } from 'mongoose'
 import { MongoDataSource } from '../datasource'
 import { isModel, isCollectionOrModel, getCollection } from '../helpers'
 
-class Users extends MongoDataSource {
-  // context;
+mongoose.set('useFindAndModify', false)
 
-  // constructor(options) {
-  //   super(options)
-  //   this.context = options.context
-  // }
+class Users extends MongoDataSource {
+  constructor(options) {
+    super(options)
+    this.context = options.context
+  }
 }
 
 describe('MongoDataSource', () => {
@@ -131,5 +131,19 @@ describe('Mongoose', () => {
 
     expect(res1[0].name).toBe('Bob')
     expect(res2[0]).toBeUndefined()
+  })
+
+  test('Data Source with Context', async () => {
+    const users = new Users({ modelOrCollection: UserModel, context: { token: '123' }})
+    
+    expect(users.context.token).toBe('123')
+  })
+
+  test('Data Source with Context that contains a User', async () => {
+    const users = new Users({ modelOrCollection: userCollection, context: { user: alice }})
+    const user = await users.findOneById(alice._id)
+
+    expect(user.name).toBe('Alice')
+    expect(users.context.user.name).toBe(user.name)
   })
 })

--- a/src/__tests__/datasource.test.js
+++ b/src/__tests__/datasource.test.js
@@ -4,19 +4,20 @@ import mongoose, { Schema, model } from 'mongoose'
 import { MongoDataSource } from '../datasource'
 import { isModel, isCollectionOrModel, getCollection } from '../helpers'
 
-mongoose.set('useFindAndModify', false)
-
 class Users extends MongoDataSource {
-  initialize(config) {
-    super.initialize(config)
-  }
+  // context;
+
+  // constructor(options) {
+  //   super(options)
+  //   this.context = options.context
+  // }
 }
 
 describe('MongoDataSource', () => {
   it('sets up caching functions', () => {
     const users = {}
-    const source = new Users(users)
-    source.initialize()
+    const source = new Users({modelOrCollection: users})
+
     expect(source.findOneById).toBeDefined()
     expect(source.findByFields).toBeDefined()
     expect(source.deleteFromCacheById).toBeDefined()
@@ -103,17 +104,15 @@ describe('Mongoose', () => {
   })
 
   test('Data Source with Model', async () => {
-    const users = new Users(UserModel)
-    users.initialize()
+    const users = new Users({ modelOrCollection: UserModel })
     const user = await users.findOneById(alice._id)
+
     expect(user.name).toBe('Alice')
     expect(user.id).toBe(alice._id.toString())
   })
 
   test('Data Source with Collection', async () => {
-    const users = new Users(userCollection)
-    users.initialize()
-
+    const users = new Users({ modelOrCollection: userCollection})
     const user = await users.findOneById(alice._id)
 
     expect(user.name).toBe('Alice')
@@ -121,9 +120,7 @@ describe('Mongoose', () => {
   })
 
   test('nested findByFields', async () => {
-    const users = new Users(userCollection)
-    users.initialize()
-
+    const users = new Users({ modelOrCollection: userCollection })
     const [user] = await users.findByFields({ 'nested._id': objectID })
 
     expect(user).toBeDefined()

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -1,31 +1,24 @@
-import { DataSource } from 'apollo-datasource'
-import { ApolloError } from 'apollo-server-errors'
-import { InMemoryLRUCache } from 'apollo-server-caching'
+import { GraphQLError } from 'graphql'
+import { InMemoryLRUCache } from '@apollo/utils.keyvaluecache'
 
 import { createCachingMethods } from './cache'
 import { isCollectionOrModel, isModel } from './helpers'
 
-class MongoDataSource extends DataSource {
-  constructor(collection) {
-    super()
 
-    if (!isCollectionOrModel(collection)) {
-      throw new ApolloError(
+class MongoDataSource {
+  constructor({modelOrCollection, cache}) {
+    if (!isCollectionOrModel(modelOrCollection)) {
+      throw new GraphQLError(
         'MongoDataSource constructor must be given a collection or Mongoose model'
       )
     }
 
-    if (isModel(collection)) {
-      this.model = collection
+    if (isModel(modelOrCollection)) {
+      this.model = modelOrCollection
       this.collection = this.model.collection
     } else {
-      this.collection = collection
+      this.collection = modelOrCollection
     }
-  }
-
-  // https://github.com/apollographql/apollo-server/blob/master/packages/apollo-datasource/src/index.ts
-  initialize({ context, cache } = {}) {
-    this.context = context
 
     const methods = createCachingMethods({
       collection: this.collection,


### PR DESCRIPTION
Made changes to make MongoDataSource more compliant to the changes made to data sources in Apollo Server 4. Removed deprecated DataSource abstract class and removed context from MongoDataSource as well as the initialize method in the MongoDataSource class. Everything is now done in the constructor, and if you need to pass context into your API class, you can add it as a member to that class directly and add it to the options object for the constructor.